### PR TITLE
 add MIT license metadata to gemspec

### DIFF
--- a/ice_nine.gemspec
+++ b/ice_nine.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
   gem.description = 'Deep Freeze Ruby Objects'
   gem.summary     = gem.description
   gem.homepage    = 'https://github.com/dkubb/ice_nine'
+  gem.license     = 'MIT'
 
   gem.require_paths    = %w[lib]
   gem.files            = `git ls-files`.split($/)


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
