### PR TITLE
Use module_function in IceNine

### DIFF
--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -2,9 +2,9 @@
 
 group :development do
   gem 'rake',       '~> 10.4.0'
-  gem 'rspec',      '~> 3.1.0'
-  gem 'rspec-core', '~> 3.1.7'
-  gem 'rspec-its',  '~> 1.1.0'
+  gem 'rspec',      '~> 3.3.0'
+  gem 'rspec-core', '~> 3.3.2'
+  gem 'rspec-its',  '~> 1.2.0'
   gem 'yard',       '~> 0.8.7.6'
 
   platform :rbx do
@@ -13,39 +13,38 @@ group :development do
 end
 
 group :yard do
-  gem 'kramdown', '~> 1.5.0'
+  gem 'kramdown', '~> 1.8.0'
 end
 
 group :guard do
-  gem 'guard',         '~> 2.10.1'
-  gem 'guard-bundler', '~> 2.0.0'
-  gem 'guard-rspec',   '~> 4.3.1'
+  gem 'guard',         '~> 2.13.0'
+  gem 'guard-bundler', '~> 2.1.0'
+  gem 'guard-rspec',   '~> 4.6.4'
   gem 'guard-rubocop', '~> 1.2.0'
 
   # file system change event handling
-  gem 'listen',     '~> 2.8.1'
+  gem 'listen',     '~> 3.0.3'
   gem 'rb-fchange', '~> 0.0.6', require: false
-  gem 'rb-fsevent', '~> 0.9.4', require: false
+  gem 'rb-fsevent', '~> 0.9.6', require: false
   gem 'rb-inotify', '~> 0.9.5', require: false
 
   # notification handling
-  gem 'libnotify',               '~> 0.8.4', require: false
+  gem 'libnotify',               '~> 0.9.1', require: false
   gem 'rb-notifu',               '~> 0.0.4', require: false
   gem 'terminal-notifier-guard', '~> 1.6.4', require: false
 end
 
 group :metrics do
   gem 'coveralls', '~> 0.7.2'
-  gem 'flay',      '~> 2.5.0'
-  gem 'flog',      '~> 4.3.0'
-  gem 'reek',      '~> 1.5.0'
-  gem 'rubocop',   '~> 0.27.1'
-  gem 'simplecov', '~> 0.9.1'
+  gem 'flay',      '~> 2.6.1'
+  gem 'flog',      '~> 4.3.2'
+  gem 'reek',      '~> 3.3.1'
+  gem 'rubocop',   '~> 0.34.0'
+  gem 'simplecov', '~> 0.10.0'
   gem 'yardstick', '~> 0.9.9'
 
   platforms :mri do
-    gem 'mutant',       '~> 0.6.7', git: 'https://github.com/mbj/mutant.git'
-    gem 'mutant-rspec', '~> 0.6.7', git: 'https://github.com/mbj/mutant.git'
+    gem 'mutant-rspec', '~> 0.8.2'
   end
 
   platforms :ruby_19, :ruby_20 do

--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@ guard :bundler do
 end
 
 # rubocop:disable LineLength
-guard :rspec, cli: File.read('.rspec').split.join(' '), keep_failed: false do
+guard :rspec, cmd: 'bundle exec rspec', cmd_additional_args: File.read('.rspec').split.join(' '), failed_mode: :none do
   # run all specs if configuration is modified
   watch('Guardfile')           { 'spec' }
   watch('Gemfile.lock')        { 'spec' }

--- a/Guardfile
+++ b/Guardfile
@@ -15,7 +15,7 @@ guard :rspec, cmd: 'bundle exec rspec', cmd_additional_args: File.read('.rspec')
   watch(%r{\Aspec/(?:lib|support|shared)/.+\.rb\z}) { 'spec' }
 
   # run unit specs if associated lib code is modified
-  watch(/\Alib\/(.+)\.rb/)                                            { |m| Dir["spec/unit/#{m[1]}"]         }
+  watch(%r{\Alib/(.+)\.rb})                                           { |m| Dir["spec/unit/#{m[1]}"]         }
   watch(%r{\Alib/(.+)/support/(.+)\.rb\z})                            { |m| Dir["spec/unit/#{m[1]}/#{m[2]}"] }
   watch("lib/#{File.basename(File.expand_path('../', __FILE__))}.rb") { 'spec'                               }
 

--- a/lib/ice_nine.rb
+++ b/lib/ice_nine.rb
@@ -24,6 +24,8 @@ require 'ice_nine/version'
 # Base IceNine module
 module IceNine
 
+  module_function
+
   # Deep Freeze an object
   #
   # @example
@@ -34,7 +36,7 @@ module IceNine
   # @return [Object]
   #
   # @api public
-  def self.deep_freeze(object)
+  def deep_freeze(object)
     Freezer.deep_freeze(object)
   end
 
@@ -55,7 +57,7 @@ module IceNine
   # @return [Object]
   #
   # @api public
-  def self.deep_freeze!(object)
+  def deep_freeze!(object)
     Freezer.deep_freeze!(object)
   end
 

--- a/lib/ice_nine/freezer.rb
+++ b/lib/ice_nine/freezer.rb
@@ -68,7 +68,7 @@ module IceNine
       freezer = name.split('::').reduce(self) do |mod, const|
         mod.const_lookup(const) or break mod
       end
-      freezer if freezer < self  # only return a descendant freezer
+      freezer if freezer < self # only return a descendant freezer
     end
 
     private_class_method :find

--- a/spec/shared/ice_nine_deep_freeze.rb
+++ b/spec/shared/ice_nine_deep_freeze.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 shared_examples 'IceNine.deep_freeze' do
-
   context 'with an Object' do
     let(:value) { Object.new }
 

--- a/spec/unit/ice_nine_spec.rb
+++ b/spec/unit/ice_nine_spec.rb
@@ -1,0 +1,29 @@
+# encoding utf-8
+
+require 'spec_helper'
+require 'ice_nine'
+
+RSpec.describe IceNine, 'module behavior' do
+  it 'exposes methods on itself' do
+    expect(subject).to respond_to(:deep_freeze)
+    expect(subject).to respond_to(:deep_freeze!)
+  end
+
+  context 'included in a class' do
+    subject { Class.new { |mod| mod.include IceNine }.new }
+
+    it 'hides IceNine methods' do
+      expect(subject).to_not respond_to(:deep_freeze)
+      expect(subject).to_not respond_to(:deep_freeze!)
+    end
+
+    it 'makes IceNine methods available to the instance' do
+      subject.instance_eval do
+        def freeze_it
+          deep_freeze(Object.new)
+        end
+      end
+      expect(subject.freeze_it).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
This enables a user to include IceNine in their classes to make its methods available to instances without the need to prefix invocations with IceNine.

I know your contributing docs ask to have a discussion with you before doing any work, but I hope that's the only rule I broke :see_no_evil: Consider this the start of a conversation about it maybe?