### PR TITLE
Fix `deep_freeze` for objects which undef freeze

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ AllCops:
     - 'benchmarks/**/*'
     - 'ice_nine.gemspec'
     - 'vendor/**/*'
+    - 'Guardfile'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,20 @@ script: "bundle exec rake ci:metrics"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.5
+  - 2.2.3
   - ruby-head
   - rbx-2
 matrix:
-  include:
+  include: []
+  allow_failures:
+    - rvm: 1.9.3
+    - rvm: 2.0.0
+    - rvm: rbx-2
+    - rvm: ruby-head
     - rvm: jruby
       env: JRUBY_OPTS="$JRUBY_OPTS --debug --1.9"  # for simplecov
     - rvm: jruby
       env: JRUBY_OPTS="$JRUBY_OPTS --debug --2.0"  # for simplecov
-  allow_failures:
-    - rvm: ruby-head
   fast_finish: true
 notifications:
   irc:

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,3 @@ end
 group :development, :test do
   gem 'devtools', git: 'https://github.com/rom-rb/devtools.git'
 end
-
-eval_gemfile 'Gemfile.devtools'

--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ Deep freeze ruby objects
 [![Build Status](https://secure.travis-ci.org/dkubb/ice_nine.svg?branch=master)][travis]
 [![Dependency Status](https://gemnasium.com/dkubb/ice_nine.svg)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/dkubb/ice_nine.png)][codeclimate]
-[![Coverage Status](https://coveralls.io/repos/dkubb/ice_nine/badge.png?branch=master)][coveralls]
 [![Inline docs](http://inch-ci.org/github/dkubb/ice_nine.svg?branch=master)][inch]
 
 [gem]: https://rubygems.org/gems/ice_nine
 [travis]: https://travis-ci.org/dkubb/ice_nine
 [gemnasium]: https://gemnasium.com/dkubb/ice_nine
 [codeclimate]: https://codeclimate.com/github/dkubb/ice_nine
-[coveralls]: https://coveralls.io/r/dkubb/ice_nine
 [inch]: http://inch-ci.org/github/dkubb/ice_nine
 
 Examples

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 8
-total_score: 50.0
+total_score: 52

--- a/config/mutant.yml
+++ b/config/mutant.yml
@@ -1,3 +1,4 @@
 ---
 name: ice_nine
 namespace: IceNine
+since: HEAD~1

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -108,3 +108,7 @@ Metrics/AbcSize:
 ClassAndModuleChildren:
   Exclude:
     - spec/**/*_spec.rb
+
+# Allow additional spaces
+ExtraSpacing:
+  Enabled: false

--- a/lib/ice_nine/freezer/object.rb
+++ b/lib/ice_nine/freezer/object.rb
@@ -16,6 +16,8 @@ module IceNine
       #
       # @return [Object]
       def self.guarded_deep_freeze(object, recursion_guard)
+        return object unless object.respond_to?(:freeze)
+
         object.freeze
         freeze_instance_variables(object, recursion_guard)
         object

--- a/spec/shared/ice_nine_deep_freeze.rb
+++ b/spec/shared/ice_nine_deep_freeze.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 shared_examples 'IceNine.deep_freeze' do
-
   context 'with an Object' do
     let(:value) { Object.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,9 @@
 
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
-  require 'coveralls'
 
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
     SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
   ]
 
   SimpleCov.start do

--- a/spec/unit/ice_nine/freezer/object/class_methods/deep_freeze_spec.rb
+++ b/spec/unit/ice_nine/freezer/object/class_methods/deep_freeze_spec.rb
@@ -23,4 +23,18 @@ describe IceNine::Freezer::Object, '.deep_freeze' do
       it_behaves_like 'IceNine::Freezer::Object.deep_freeze'
     end
   end
+
+  context 'with an Object which undefs :freeze' do
+    let(:value) { UndefFreeze.new }
+
+    before do
+      klass = Class.new do
+        undef :freeze
+      end
+
+      stub_const('UndefFreeze', klass)
+    end
+
+    it_behaves_like 'IceNine::Freezer::NoFreeze.deep_freeze'
+  end
 end


### PR DESCRIPTION
Relevant to implementations which try to freeze an instance of a class that includes `Adamantium` which leads to an attempt to freeze `ThreadSafe::Cache`: https://github.com/ruby-concurrency/thread_safe/blob/master/lib/thread_safe/cache.rb#L135