### PR TITLE
Update CI Ruby versions to latest supported versions 3.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version:
+          - '3.2'
+          - '3.3'
+          - '3.4'
+          - 'ruby-head'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development, :test do
   gem 'mutant',       github: 'mbj/mutant'
   gem 'mutant-rspec', github: 'mbj/mutant'
 
+  gem 'bigdecimal'
+
   source 'https://oss:sxCL1o1navkPi2XnGB5WYBrhpY9iKIPL@gem.mutant.dev' do
     gem 'mutant-license'
   end

--- a/config/mutant.yml
+++ b/config/mutant.yml
@@ -10,3 +10,4 @@ mutation:
   timeout: 1.0
 coverage_criteria:
   timeout: true
+usage: opensource


### PR DESCRIPTION
Also added ruby-head to ensure we'll be ahead of any breaking changes in the future.

I also: updated github actions to v4, added a required configuration for mutant and added `bigdecimal` to the Gemfile for tests to run on 3.4+.

We use ice_nine in [dry-struct](https://github.com/dry-rb/dry-struct), which is used in [rom](https://github.com/rom-rb/rom/blob/d2de00f6249d17aea7965573972633677018f4cf/core/lib/rom/struct.rb#L14), and that's used in [hanami-db](https://github.com/hanami/db), so we want to help make sure it stays maintained on latest ruby versions :)